### PR TITLE
Remove country flags from language menu.

### DIFF
--- a/userguide/inc/config_export.php
+++ b/userguide/inc/config_export.php
@@ -92,7 +92,7 @@ function document_hook($path_original, $path_translations, $doc_id, $lang_code, 
 		$menu = <<<EOD
 
 <ul class="lang-menu">
-<li class="now"><img src="$flags_path$lang_code.png" alt="" /> $langs[$lang_code]</li>
+<li class="now">$langs[$lang_code]&nbsp;<span class="dropdown-caret">&#9660;</span></li>
 
 EOD;
 		foreach ($langs as $current_code => $name) {
@@ -105,7 +105,7 @@ EOD;
 				$url = str_replace('{LANG}', $current_code, $trans_url);
 
 			$menu .= <<<EOD
-<li><a href="$url"><img src="$flags_path$current_code.png" alt="" />$langs[$current_code]</a></li>
+<li><a href="$url">$langs[$current_code]</a></li>
 
 EOD;
 		}


### PR DESCRIPTION
Following the discussion on Haiku ticket #15311[1], this change removes the country
flags and replaces it with a downward caret to indicate that the user will get a
dropdown menu on hover.

Additionally, the Haiku-doc.css file in the userguide translator will be amended
with the following:

ul.lang-menu li.now span.dropdown-caret {
	color: #aaaaaa;
	position: relative;
	top: -0.1em;
}

This change fixes #15393[2]

[1] https://dev.haiku-os.org/ticket/15311
[2] https://dev.haiku-os.org/ticket/15393