### PR TITLE
Keep table headers visible when scrolling long tables

### DIFF
--- a/userguide/admin/docs.php
+++ b/userguide/admin/docs.php
@@ -80,9 +80,12 @@ include('../inc/start_html.php');
 <form action="" method="post">
 <h1><?=$title?></h1>
 <table class="list">
+<thead>
 <tr>
 <th>&nbsp;</th><th>Name</th><th>Source path</th><th>Translations path</th><th>Disabled</th>
 </tr>
+</thead>
+<tbody>
 <?php
 $req = db_query('SELECT doc_id, name, path_original, path_translations, is_disabled ' . '
 	FROM ' . DB_DOCS);
@@ -107,6 +110,7 @@ while ($row = db_fetch($req)) {
 <input type="submit" name="delete_selection" value="Delete selection" />
 </td>
 </tr>
+</tbody>
 </table>
 </form>
 <?php

--- a/userguide/admin/langs.php
+++ b/userguide/admin/langs.php
@@ -87,9 +87,12 @@ if (isset($_POST['update_status'])) {
 <h1>Languages</h1>
 <form action="" method="post">
 <table class="list">
+<thead>
 <tr>
 <th>English name</th><th>Localized name</th><th style="width:2em">Disabled</th><th style="width:5em">Options</th>
 </tr>
+</thead>
+<tbody>
 <?php
 $req = db_query('SELECT * FROM ' . DB_LANGS);
 if (db_num_rows($req) > 0) {
@@ -115,6 +118,7 @@ if (db_num_rows($req) > 0) {
 <input type="submit" name="update_status" value="Update status" />
 </td>
 </tr>
+</tbody>
 </table>
 <dl class="fieldset">
 <dt><span>Add new language</span></dt>

--- a/userguide/admin/resources_unhand.php
+++ b/userguide/admin/resources_unhand.php
@@ -129,9 +129,12 @@ function select_matching() {
 </script>
 <form action="" method="post">
 <table class="list">
+<thead>
 <tr>
 <th style="width:20px">&nbsp;</th><th>File name</th>
 </tr>
+</thead>
+<tbody>
 <?php
 foreach ($unhandled_paths as $path) {
 	$path = htmlspecialchars($path);
@@ -153,6 +156,7 @@ foreach ($unhandled_paths as $path) {
 <span id="match_status"></span>
 </td>
 </tr>
+</tbody>
 </table>
 </form>
 

--- a/userguide/admin/users.php
+++ b/userguide/admin/users.php
@@ -154,10 +154,13 @@ if (isset($_POST['new_user_name']) and isset($_POST['new_user_role'])
 <form action="" method="post">
 <h1>Users</h1>
 <table class="list">
+<thead>
 <tr>
 <th style="width:20px">&nbsp;</th><th>Name</th><th>Email</th><th style="width:5%">Role</th>
 <th style="width:5%">Edits</th><th style="width:5%">Translations</th><th style="width:10%">Options</th>
 </tr>
+</thead>
+<tbody>
 <?php
 $req = db_query('SELECT * FROM ' . DB_USERS . ' ORDER BY username');
 while ($row = db_fetch($req)) {
@@ -203,6 +206,7 @@ while ($row = db_fetch($req)) {
 <input type="submit" name="delete_selection" value="Delete selection" />
 </td>
 </tr>
+</tbody>
 </table>
 </form>
 <br/>

--- a/userguide/edit.php
+++ b/userguide/edit.php
@@ -107,9 +107,12 @@ if (isset($_POST['text'])) {
 		if (!empty($blocks['add'])) {
 ?>
 <table class="list">
+<thead>
 <tr>
 <th>Added blocks</th>
 </tr>
+</thead>
+<tbody>
 <?php
 			foreach ($blocks['add'] as $added_block) {
 ?>
@@ -119,6 +122,7 @@ if (isset($_POST['text'])) {
 <?php
 			}
 ?>
+</tbody>
 </table>
 <br/>
 <?php
@@ -126,9 +130,12 @@ if (isset($_POST['text'])) {
 		if (!empty($blocks['mod'])) {
 ?>
 <table class="list" style="overflow-x:auto">
+<thead>
 <tr>
 <th>Modified blocks - Original</th><th>New</th>
 </tr>
+</thead>
+<tbody>
 <?php
 			foreach ($blocks['mod'] as $id => $modif_block) {
 				$original_block = nl2br(htmlspecialchars($modif_block['p']));
@@ -145,6 +152,7 @@ Do not invalidate translations for this item</label>
 <?php
 			}
 ?>
+</tbody>
 </table>
 <br/>
 <?php
@@ -152,9 +160,12 @@ Do not invalidate translations for this item</label>
 		if (!empty($blocks['del'])) {
 ?>
 <table class="list">
+<thead>
 <tr>
 <th>Deleted blocks</th>
 </tr>
+</thead>
+<tbody>
 <?php
 			foreach ($blocks['del'] as $del_block) {
 ?>
@@ -164,6 +175,7 @@ Do not invalidate translations for this item</label>
 <?php
 			}
 ?>
+</tbody>
 </table>
 <br/>
 <?php

--- a/userguide/shared/styles.css
+++ b/userguide/shared/styles.css
@@ -373,6 +373,11 @@ table.list {
 	width: 100%;
 }
 
+table.list thead {
+	position: sticky;
+	top: 0;
+}
+
 table.list th {
 	color: black;
 	background: -webkit-gradient(linear, left top, left bottom, from(#F7F7F7), to(#C6C6C6));


### PR DESCRIPTION
At least in some browsers. Both firefox and WebPositive work for me.