### PR TITLE
Replace LANG_CODE in live views

### DIFF
--- a/userguide/block_edit.php
+++ b/userguide/block_edit.php
@@ -183,6 +183,8 @@ $js .= "const doc_id = $doc_id;\n";
 $js .= "var source_strings = new Array();\n";
 $js .= get_source_strings($doc);
 
+$doc->loadXML(str_replace('{LANG_CODE}', 'en', $doc->saveXML()));
+
 $head = $doc->getElementsByTagName('head')->item(0);
 
 // Set the base dir

--- a/userguide/block_edit.php
+++ b/userguide/block_edit.php
@@ -183,7 +183,7 @@ $js .= "const doc_id = $doc_id;\n";
 $js .= "var source_strings = new Array();\n";
 $js .= get_source_strings($doc);
 
-$doc->loadXML(str_replace('{LANG_CODE}', 'en', $doc->saveXML()));
+$doc->loadXML(replace_placeholders($doc->saveXML()));
 
 $head = $doc->getElementsByTagName('head')->item(0);
 

--- a/userguide/inc/common.php
+++ b/userguide/inc/common.php
@@ -266,6 +266,10 @@ function count_str($needle, $haystack) {
 	}
 }
 
+function replace_placeholders($text, $lang = null) {
+	return str_replace('{LANG_CODE}', ($lang ? $lang : 'en'), $text);
+}
+
 function sub_glob($path, $expr, $continue) {
 	$expr = preg_quote($expr, '=');
 	$expr = '=' . str_replace('\*', '.*', $expr) . '=';

--- a/userguide/inc/config_export.php
+++ b/userguide/inc/config_export.php
@@ -81,7 +81,7 @@ function document_hook($path_original, $path_translations, $doc_id, $lang_code, 
 		$orig_url = $back . implode('/', $orig_items);
 		$trans_url = $back . implode('/', $trans_items);
 
-		$generated_text = str_replace('{LANG_CODE}', ($lang_code ? $lang_code : 'en'), $generated_text);
+		$generated_text = replace_placeholders($generated_text, $lang_code);
 
 		if ($lang_code) {
 			$generated_text = preg_replace_callback('!<div class="inner"><span>.*?</span></div>!s', 'header_callback', $generated_text);

--- a/userguide/shared/block_edit_tool.js
+++ b/userguide/shared/block_edit_tool.js
@@ -38,7 +38,7 @@ function endEditionEvent(clickOK) {
 		xml_http.userguide_new_text = new_text;
 		return;
 	} else {
-		window.edited_node.innerHTML = source_strings[id];
+		window.edited_node.innerHTML = formatText(source_strings[id]);
 	}
 
 	edit_window.close();
@@ -68,7 +68,7 @@ function editSaveFinished() {
 		send_ok = true;
 
 	for (var i = 0 ; i < linked_nodes[id].length ; i++) {
-		linked_nodes[id][i].innerHTML = new_text;
+		linked_nodes[id][i].innerHTML = formatText(new_text);
 		linked_nodes[id][i].style.backgroundColor = null;
 	}
 
@@ -166,6 +166,10 @@ function setProperties(node) {
 	for (var i = 0 ; i < node.childNodes.length ; i++) {
 		setProperties(node.childNodes[i]);
 	}
+}
+
+function formatText(s) {
+	return s.replace(/\{LANG_CODE\}/g, 'en');
 }
 
 window.onload = function() {

--- a/userguide/shared/edit_tool.html
+++ b/userguide/shared/edit_tool.html
@@ -10,7 +10,7 @@ function updateEvent() {
 	var text = document.getElementById('modified').value
 
 	var previous = window.opener.edited_node.innerHTML;
-	window.opener.edited_node.innerHTML = text;
+	window.opener.edited_node.innerHTML = window.opener.formatText(text);
 
 	if (window.opener.edited_node.innerText == '')
 		window.opener.edited_node.innerHTML = previous;

--- a/userguide/shared/edit_tool.js
+++ b/userguide/shared/edit_tool.js
@@ -44,9 +44,10 @@ function updateStatus() {
 	if (!preview_window)
 		return;
 
-	preview_window.document.write(editor.value.replace('<head>',
-		'<head><base href="' + base_dir + '" />'));
-		preview_window.document.close();
+	preview_window.document.write(editor.value
+		.replace('<head>', '<head><base href="' + base_dir + '" />')
+		.replace(/\{LANG_CODE\}/g, 'en'));
+	preview_window.document.close();
 }
 
 function togglePreview() {

--- a/userguide/shared/translate_tool.html
+++ b/userguide/shared/translate_tool.html
@@ -45,7 +45,7 @@ function updateEvent() {
 	}
 
 	var previous = window.opener.edited_node.innerHTML;
-	window.opener.edited_node.innerHTML = text;
+	window.opener.edited_node.innerHTML = window.opener.formatText(text);
 
 	if (window.opener.edited_node.innerText == '')
 		window.opener.edited_node.innerHTML = previous;

--- a/userguide/shared/translate_tool.js
+++ b/userguide/shared/translate_tool.js
@@ -53,10 +53,10 @@ function endEditionEvent(clickOK) {
 		xml_http.userguide_mark_fuzzy = mark_fuzzy;
 		return;
 	} else {
-		window.edited_node.innerHTML = translated_strings[id];
+		window.edited_node.innerHTML = formatText(translated_strings[id]);
 		if (window.edited_node.innerHTML == ''
 			|| window.edited_node.innerText == '')
-			window.edited_node.innerHTML = source_strings[id];
+			window.edited_node.innerHTML = formatText(source_strings[id]);
 		translateBlockDone(next_node);
 	}
 }
@@ -89,7 +89,7 @@ function translateSaveFinished() {
 	is_fuzzy[id] = this.userguide_mark_fuzzy;
 
 	for (var i = 0 ; i < linked_nodes[id].length ; i++) {
-		linked_nodes[id][i].innerHTML = this.userguide_trans;
+		linked_nodes[id][i].innerHTML = formatText(this.userguide_trans);
 		linked_nodes[id][i].style.border = '1px dotted ' +
 			(send_ok ? color_translated : color_unsent);
 		linked_nodes[id][i].style.backgroundColor = null;
@@ -207,10 +207,10 @@ function setProperties(node) {
 					} else if (is_fuzzy[id]) {
 						node.style.border = '1px dotted ' + color_fuzzy;
 						node.style.backgroundColor = bg_fuzzy;
-						node.innerHTML = translated_strings[id];
+						node.innerHTML = formatText(translated_strings[id]);
 					} else {
 						node.style.border = '1px dotted ' + color_translated;
-						node.innerHTML = translated_strings[id];
+						node.innerHTML = formatText(translated_strings[id]);
 					}
 
 					node.onmouseover = mouseOverEvent;
@@ -251,6 +251,10 @@ function setProperties(node) {
 	for (var i = 0 ; i < node.childNodes.length ; i++) {
 		setProperties(node.childNodes[i]);
 	}
+}
+
+function formatText(s) {
+	return s.replace(/\{LANG_CODE\}/g, lang);
 }
 
 window.onload = function() {

--- a/userguide/translate.php
+++ b/userguide/translate.php
@@ -162,6 +162,8 @@ $js .= get_source_strings($doc);
 
 db_free($req);
 
+$doc->loadXML(str_replace('{LANG_CODE}', $lang, $doc->saveXML()));
+
 $head = $doc->getElementsByTagName('head')->item(0);
 
 // Redirect all links of the page to the translated version

--- a/userguide/translate.php
+++ b/userguide/translate.php
@@ -162,7 +162,7 @@ $js .= get_source_strings($doc);
 
 db_free($req);
 
-$doc->loadXML(str_replace('{LANG_CODE}', $lang, $doc->saveXML()));
+$doc->loadXML(replace_placeholders($doc->saveXML(), $lang));
 
 $head = $doc->getElementsByTagName('head')->item(0);
 

--- a/userguide/view.php
+++ b/userguide/view.php
@@ -71,7 +71,7 @@ html_set_lang($doc, $lang);
 
 replace_translations($doc, $doc);
 
-echo str_replace('{LANG_CODE}', ($lang ? $lang : 'en'), $doc->saveXML());
+echo replace_placeholders($doc->saveXML(), $lang);
 
 function replace_translations($doc, $node) {
 	global $translations;

--- a/userguide/view.php
+++ b/userguide/view.php
@@ -71,7 +71,7 @@ html_set_lang($doc, $lang);
 
 replace_translations($doc, $doc);
 
-echo $doc->saveXML();
+echo str_replace('{LANG_CODE}', ($lang ? $lang : 'en'), $doc->saveXML());
 
 function replace_translations($doc, $node) {
 	global $translations;


### PR DESCRIPTION
`{LANG_CODE}` is replaced by the language code on export. This is
particularly useful for links to other guides. Let's make that visible
also when viewing/editing/translating the document.