### PR TITLE
Fix: keep fuzzyness on source text modification

### DIFF
--- a/userguide/block_edit.php
+++ b/userguide/block_edit.php
@@ -92,8 +92,8 @@ if (isset($_POST['edit_doc']) and isset($_POST['edit_string'])
 		}
 
 		$fuzzy = !$_POST['dont_mark_fuzzy'];
-		$update = 'source_md5' . $r_norm . ($fuzzy ? $r_fuzzy : '');
-		$up_to = "'$md5'" . $r_norm . ($fuzzy ? $r_to_fuzzy : '');
+		$update = 'source_md5' . $r_norm . $r_fuzzy;
+		$up_to = "'$md5'" . $r_norm . ($fuzzy ? $r_to_fuzzy : $r_fuzzy);
 		db_query('INSERT INTO ' . DB_STRINGS . " ($update)
 			SELECT $up_to FROM " . DB_STRINGS . "
 			WHERE string_id = ?", array($string_id));

--- a/userguide/block_edit.php
+++ b/userguide/block_edit.php
@@ -81,20 +81,19 @@ if (isset($_POST['edit_doc']) and isset($_POST['edit_string'])
 			SET unused_since = ?
 			WHERE string_id = ?", array($time, $string_id));
 	} else {
-		$r_norm = 'doc_id';
+		$r_norm = ', doc_id';
 		$r_fuzzy = '';
 		$r_to_fuzzy = '';
 		$req = db_query('SELECT lang_code FROM ' . DB_LANGS);
 		while ($row = db_fetch($req)) {
 			$r_norm .= ', "translation_' . $row['lang_code'] . '"';
-			$r_fuzzy .= ($r_fuzzy ? ', ' : '') . '"is_fuzzy_' .
-				$row['lang_code'] . '"';
-			$r_to_fuzzy .= ($r_to_fuzzy ? ', ' : '') . '1';
+			$r_fuzzy .= ', "is_fuzzy_' . $row['lang_code'] . '"';
+			$r_to_fuzzy .= ', 1';
 		}
 
 		$fuzzy = !$_POST['dont_mark_fuzzy'];
-		$update = 'source_md5' . ($r_norm ? ', ' : '') . $r_norm . (($fuzzy and $r_fuzzy) ? ', ' . $r_fuzzy : '');
-		$up_to = "'$md5'" . ($r_norm ? ', ' : '') . $r_norm . (($fuzzy and $r_to_fuzzy) ? ', ' . $r_to_fuzzy : '');
+		$update = 'source_md5' . $r_norm . ($fuzzy ? $r_fuzzy : '');
+		$up_to = "'$md5'" . $r_norm . ($fuzzy ? $r_to_fuzzy : '');
 		db_query('INSERT INTO ' . DB_STRINGS . " ($update)
 			SELECT $up_to FROM " . DB_STRINGS . "
 			WHERE string_id = ?", array($string_id));

--- a/userguide/edit.php
+++ b/userguide/edit.php
@@ -227,14 +227,13 @@ Do not invalidate translations for this item</label>
 		die('Error parsing the XML document !');
 
 	$req = db_query('SELECT lang_code FROM ' . DB_LANGS);
-	$r_norm = 'doc_id';
+	$r_norm = ', doc_id';
 	$r_fuzzy = '';
 	$r_to_fuzzy = '';
 	while ($row = db_fetch($req)) {
 		$r_norm .= ', "translation_' . $row['lang_code'] . '"';
-		$r_fuzzy .= ($r_fuzzy ? ', ' : '') . '"is_fuzzy_' .
-			$row['lang_code'] . '"';
-		$r_to_fuzzy .= ($r_to_fuzzy ? ', ' : '') . '1';
+		$r_fuzzy .= ', "is_fuzzy_' . $row['lang_code'] . '"';
+		$r_to_fuzzy .= ', 1';
 	}
 	db_free($req);
 
@@ -532,10 +531,10 @@ function update_translations($node, $tags) {
 				} else {
 					// ID in the DB, but the block was modified
 					$fuzzy = !isset($_POST['noinval'][$id_attr]);
-					$update = 'source_md5, ' . $r_norm .
-						(($fuzzy and $r_fuzzy) ? ', ' . $r_fuzzy : '');
-					$up_to = "'$md5', " .
-						$r_norm . (($fuzzy and $r_to_fuzzy) ? ', ' . $r_to_fuzzy : '');
+					$update = 'source_md5' . $r_norm .
+						($fuzzy ? $r_fuzzy : '');
+					$up_to = "'$md5'" . $r_norm .
+						($fuzzy ? $r_to_fuzzy : '');
 
 					db_query('INSERT INTO ' . DB_STRINGS . " ($update)
 						SELECT $up_to FROM " . DB_STRINGS . "

--- a/userguide/edit.php
+++ b/userguide/edit.php
@@ -531,10 +531,9 @@ function update_translations($node, $tags) {
 				} else {
 					// ID in the DB, but the block was modified
 					$fuzzy = !isset($_POST['noinval'][$id_attr]);
-					$update = 'source_md5' . $r_norm .
-						($fuzzy ? $r_fuzzy : '');
+					$update = 'source_md5' . $r_norm . $r_fuzzy;
 					$up_to = "'$md5'" . $r_norm .
-						($fuzzy ? $r_to_fuzzy : '');
+						($fuzzy ? $r_to_fuzzy : $r_fuzzy);
 
 					db_query('INSERT INTO ' . DB_STRINGS . " ($update)
 						SELECT $up_to FROM " . DB_STRINGS . "


### PR DESCRIPTION
When a translatable block is changed with new text and marked to not invalidate current translations, the fuzzy bits are not copied and so current fuzzy translations are marked as finished instead.

Always include the fuzzy columns, either all set when invalidating translations or with the previous values when not invalidating them.